### PR TITLE
Check metadata uniqueness and element unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,28 @@ cat-embedding match --gallery gallery.npz --query query.json --thr 0.80 --margin
 - 위치 정보가 유효하면 `--bounds '[minLat,maxLat,minLon,maxLon]'`로 정규화 범위를 지정하면 도움이 됩니다.
 - 애매한 케이스에서는 `--thr`(임계값)과 `--margin`(마진)을 조정해 보세요.
 
+### 📍 위치 데이터(EXIF GPS)
+
+- **자동 추출**: 메타데이터에 `lat`/`lon`이 누락되었거나 `null`이면, 이미지의 EXIF GPS에서 위경도를 자동으로 추출해 사용합니다.
+- **우선순위**: 메타데이터에 `lat`/`lon`이 명시되어 있으면 EXIF값보다 메타데이터 값을 사용합니다.
+- **없을 때의 처리**: EXIF GPS가 없거나 파싱에 실패하면 위치 벡터는 0으로 처리됩니다(위치 정보 비사용과 동일).
+- **정규화 범위**: `--bounds '[minLat,maxLat,minLon,maxLon]'`를 지정하면 위치를 구간 내에서 0~1로 정규화합니다.
+- **주의**: 일부 편집/리사이즈 도구는 EXIF를 제거합니다. 이미지에 GPS가 포함되어 있어야 자동 추출이 가능합니다.
+
+예시(위치 누락 → EXIF 사용):
+
+```json
+{
+  "cat_id": "cat_001",
+  "image_path": "path/to/photo_with_gps.jpg",
+  "ear_tip": "left",
+  "nose_color": "pink",
+  "eye_color": "yellow",
+  "coat_type": "ginger_tabby",
+  "has_stripes": true
+}
+```
+
 ## 🔗 관련 링크
 
 - [OpenAI CLIP](https://github.com/openai/CLIP)

--- a/src/cat_embedding/__init__.py
+++ b/src/cat_embedding/__init__.py
@@ -1,4 +1,8 @@
-from .__main__ import main
-
 __version__ = "0.1.0"
+
+def main():
+    # Lazy import to avoid importing heavy modules at package import time
+    from .__main__ import main as _main
+    _main()
+
 __all__ = ["main"]

--- a/src/cat_embedding/geo.py
+++ b/src/cat_embedding/geo.py
@@ -1,6 +1,7 @@
 # src/cat_embedding/geo.py
 import numpy as np
 from typing import Optional, Tuple
+from PIL import Image, ExifTags
 
 def normalize_latlon(lat: Optional[float], lon: Optional[float],
                      bounds: Optional[Tuple[float,float,float,float]] = None) -> np.ndarray:
@@ -13,3 +14,90 @@ def normalize_latlon(lat: Optional[float], lon: Optional[float],
     nlat = (lat - min_lat) / (max_lat - min_lat)
     nlon = (lon - min_lon) / (max_lon - min_lon)
     return np.clip(np.array([nlat, nlon], dtype=float), 0.0, 1.0)
+
+
+def _rational_to_float(value) -> float:
+    """Converts a PIL Exif rational or tuple to float.
+
+    Handles PIL's IFDRational type and (numerator, denominator) tuples.
+    """
+    try:
+        # PIL.IFDRational has numerator/denominator attributes
+        numerator = getattr(value, "numerator", None)
+        denominator = getattr(value, "denominator", None)
+        if numerator is not None and denominator:
+            return float(numerator) / float(denominator)
+    except Exception:
+        pass
+
+    if isinstance(value, tuple) and len(value) == 2 and value[1] not in (0, None):
+        return float(value[0]) / float(value[1])
+
+    # Fallback
+    return float(value)
+
+
+def _dms_to_degrees(dms, ref: str) -> Optional[float]:
+    """Convert EXIF GPS DMS format to decimal degrees.
+
+    dms is typically a sequence of three rationals: (deg, min, sec).
+    ref is one of 'N','S','E','W'.
+    """
+    if not dms or len(dms) != 3:
+        return None
+    try:
+        degrees = _rational_to_float(dms[0])
+        minutes = _rational_to_float(dms[1])
+        seconds = _rational_to_float(dms[2])
+        decimal = degrees + (minutes / 60.0) + (seconds / 3600.0)
+        if ref in ("S", "W"):
+            decimal = -decimal
+        return decimal
+    except Exception:
+        return None
+
+
+def extract_gps_from_image(image_path: str) -> Optional[Tuple[float, float]]:
+    """Extract (lat, lon) from image EXIF GPS if available.
+
+    Returns None if GPS is not present or cannot be parsed.
+    """
+    try:
+        img = Image.open(image_path)
+        # Pillow >= 6: use getexif(); older: _getexif()
+        exif = getattr(img, "getexif", None)
+        exif_data = exif() if callable(exif) else getattr(img, "_getexif", lambda: None)()
+        if not exif_data:
+            return None
+
+        # GPSInfo tag id in EXIF is 34853
+        gps_tag_id = None
+        for tag_id, tag_name in ExifTags.TAGS.items():
+            if tag_name == "GPSInfo":
+                gps_tag_id = tag_id
+                break
+        if gps_tag_id is None or gps_tag_id not in exif_data:
+            return None
+
+        gps_info = exif_data[gps_tag_id]
+        # gps_info can be a dict keyed by ints; translate keys using GPSTAGS names
+        gps = {}
+        for key, val in getattr(gps_info, "items", lambda: [])():
+            name = ExifTags.GPSTAGS.get(key, key)
+            gps[name] = val
+
+        lat_ref = gps.get("GPSLatitudeRef")
+        lat_dms = gps.get("GPSLatitude")
+        lon_ref = gps.get("GPSLongitudeRef")
+        lon_dms = gps.get("GPSLongitude")
+        if not lat_ref or not lat_dms or not lon_ref or not lon_dms:
+            return None
+
+        lat = _dms_to_degrees(lat_dms, lat_ref)
+        lon = _dms_to_degrees(lon_dms, lon_ref)
+        if lat is None or lon is None:
+            return None
+        return float(lat), float(lon)
+    except Exception:
+        # Any error leads to graceful fallback to None
+        return None

--- a/tests/test_geo_integration.py
+++ b/tests/test_geo_integration.py
@@ -1,0 +1,117 @@
+import numpy as np
+import os
+import sys
+from types import ModuleType
+from PIL import Image
+import pytest
+
+from cat_embedding.schema import CatMeta
+from cat_embedding.geo import extract_gps_from_image
+
+
+def _with_stubbed_sklearn_import_gallery(monkeypatch):
+    """Import cat_embedding.gallery with a stubbed sklearn.metrics.pairwise.
+
+    This avoids installing scikit-learn on Python 3.13 where wheels may be unavailable.
+    """
+    # Build stub hierarchy: sklearn -> sklearn.metrics -> sklearn.metrics.pairwise
+    sklearn_stub = ModuleType("sklearn")
+    metrics_stub = ModuleType("sklearn.metrics")
+    pairwise_stub = ModuleType("sklearn.metrics.pairwise")
+
+    def cosine_similarity(X, Y):
+        X = np.asarray(X)
+        Y = np.asarray(Y)
+        # Very simple cosine sim (not used in these tests)
+        x = X / (np.linalg.norm(X, axis=1, keepdims=True) + 1e-9)
+        y = Y / (np.linalg.norm(Y, axis=1, keepdims=True) + 1e-9)
+        return x @ y.T
+
+    pairwise_stub.cosine_similarity = cosine_similarity
+    metrics_stub.pairwise = pairwise_stub
+
+    monkeypatch.setitem(sys.modules, "sklearn", sklearn_stub)
+    monkeypatch.setitem(sys.modules, "sklearn.metrics", metrics_stub)
+    monkeypatch.setitem(sys.modules, "sklearn.metrics.pairwise", pairwise_stub)
+
+    import importlib
+    return importlib.import_module("cat_embedding.gallery")
+
+
+def _make_temp_image(path: str, size=(10, 10), color=(128, 128, 128)):
+    img = Image.new("RGB", size, color)
+    img.save(path)
+
+
+def test_extract_gps_from_image_returns_none_without_exif(tmp_path):
+    img_path = os.path.join(tmp_path, "no_exif.jpg")
+    _make_temp_image(img_path)
+    assert extract_gps_from_image(img_path) is None
+
+
+def test_build_vector_uses_exif_when_latlon_missing(monkeypatch, tmp_path):
+    # Arrange: image file
+    img_path = os.path.join(tmp_path, "img.jpg")
+    _make_temp_image(img_path)
+
+    gallery = _with_stubbed_sklearn_import_gallery(monkeypatch)
+
+    # Stub image_embedding to a small fixed vector to keep test light
+    monkeypatch.setattr(gallery, "image_embedding", lambda p: np.ones(8, dtype=float))
+
+    # Capture lat/lon sent into normalize_latlon
+    captured = {}
+
+    def fake_normalize(lat, lon, bounds=None):
+        captured["lat"], captured["lon"], captured["bounds"] = lat, lon, bounds
+        return np.array([0.5, 0.5], dtype=float)
+
+    monkeypatch.setattr(gallery, "normalize_latlon", fake_normalize)
+
+    # Provide EXIF GPS via stub (we are testing integration behavior, not EXIF parsing here)
+    monkeypatch.setattr(gallery, "extract_gps_from_image", lambda p: (37.1, 127.2))
+
+    meta = CatMeta(image_path=img_path)
+
+    # Act
+    vec = gallery.build_vector(meta, bounds=(36.0, 38.0, 126.0, 128.0))
+
+    # Assert: normalize_latlon should have received EXIF-derived values
+    assert captured["lat"] == 37.1 and captured["lon"] == 127.2
+    # Vector should be non-empty and normalized
+    assert isinstance(vec, np.ndarray) and vec.size > 0
+    # Final vector should be L2-normalized (approximately 1)
+    norm = float(np.linalg.norm(vec))
+    assert 0.99 <= norm <= 1.01
+
+
+def test_build_vector_uses_provided_latlon_when_present(monkeypatch, tmp_path):
+    img_path = os.path.join(tmp_path, "img2.jpg")
+    _make_temp_image(img_path)
+
+    gallery = _with_stubbed_sklearn_import_gallery(monkeypatch)
+
+    monkeypatch.setattr(gallery, "image_embedding", lambda p: np.ones(8, dtype=float))
+
+    # Make EXIF extraction raise if called; it must NOT be called when lat/lon provided
+    def exif_should_not_be_called(_):
+        raise AssertionError("extract_gps_from_image should not be called when lat/lon provided")
+
+    monkeypatch.setattr(gallery, "extract_gps_from_image", exif_should_not_be_called)
+
+    captured = {}
+
+    def fake_normalize(lat, lon, bounds=None):
+        captured["lat"], captured["lon"], captured["bounds"] = lat, lon, bounds
+        return np.array([0.25, 0.75], dtype=float)
+
+    monkeypatch.setattr(gallery, "normalize_latlon", fake_normalize)
+
+    meta = CatMeta(image_path=img_path, lat=35.5, lon=127.7)
+
+    vec = gallery.build_vector(meta, bounds=(30.0, 40.0, 120.0, 130.0))
+
+    assert captured["lat"] == 35.5 and captured["lon"] == 127.7
+    assert isinstance(vec, np.ndarray) and vec.size > 0
+    norm = float(np.linalg.norm(vec))
+    assert 0.99 <= norm <= 1.01


### PR DESCRIPTION
Add EXIF GPS extraction from images to automatically populate missing latitude and longitude metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f08cdf6-fefc-43c5-adf9-8193e23a42f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f08cdf6-fefc-43c5-adf9-8193e23a42f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

